### PR TITLE
Updated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pycsg==0.3.3
-svg.path==3.0
+svg.path==7.0
 Pint==0.9.0
 geomdl==5.2.9
 freetype-py==2.1.0.post1
+pythreejs==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         "pycsg >= 0.3.3",
-        "svg.path==3.0",
-        "Pint==0.9.0"
+        "svg.path==7.0",
+        "Pint==0.9.0",
+        "pythreejs==2.4.2"
     ],
 )


### PR DESCRIPTION
The old svg.path version threw an error on newer python versions.  Upgrading it doesn't appear to break anything.

I also added the pythreejs dependency so the ipynb examples render - though I suppose it's arguably not a true dependency of the library itself.  Whatever you think.